### PR TITLE
Fix syntax error in Get-ConditionalAccessSignIn.ps1 filter condition

### DIFF
--- a/Get-ConditionalAccessSignIn.ps1
+++ b/Get-ConditionalAccessSignIn.ps1
@@ -89,7 +89,7 @@ function Get-ConditionalAccessSignIn {
             if($SignInTypeObject -eq 'Non-Interactive'){
                 $Filter += " and (signInEventTypes/any(t: t ne 'interactiveUser'))"
             }else {
-                $Filter += " and (signInEventTypes/any(t: t eq 'interactiveUser')"
+                $Filter += " and (signInEventTypes/any(t: t eq 'interactiveUser'))"
             }
             
 


### PR DESCRIPTION
added missing ')' for the interactive filter.